### PR TITLE
Handle 'Wrong Information' and 'File exists' errors in createStudentFile function

### DIFF
--- a/ex.test.js
+++ b/ex.test.js
@@ -117,6 +117,17 @@ describe("Exercise 2: Student File Creation with Validation in Node.js", () => {
       done();
     });
   });
+
+  test("returns 'Wrong Information' error before 'File exists' error", (done) => {
+    // Create a file before test
+    fs.writeFileSync(filename, "Initial content");
+    const wrongInfo = { ...studentInfo, firstName: "Mark", surName: "Twain" };
+    createStudentFile(studentName, wrongInfo, (err) => {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe("Wrong Information");
+      done();
+    });
+  });
 });
 
 describe("Exercise 3: Using Promises in Asynchronous JavaScript", () => {


### PR DESCRIPTION
This commit adds a new test case to ensure that the 'createStudentFile' function checks for 'Wrong Information' error before 'File exists' error. The test case creates a file before running 'createStudentFile' with incorrect student information. The expected behavior is that 'createStudentFile' should return a 'Wrong Information' error, verifying that it checks the student information before checking if the file exists. This test case helps prevent false positives in the test suite by ensuring the correct order of error checks.